### PR TITLE
Enable search tracking

### DIFF
--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -88,7 +88,13 @@
     <script type="text/javascript">
       var _paq = _paq || [];
       _paq.push(['disableCookies']);
+
+      {% if pageName == "search" %}
+      _paq.push(['trackSiteSearch', "{{ query }}", false, {{ results.length }}]);
+      {% else %}
       _paq.push(['trackPageView']);
+      {% endif %}
+
       _paq.push(['enableLinkTracking']);
       (function() {
         var u="//bug.openrightsgroup.org/piwik/";

--- a/views/search/search.html
+++ b/views/search/search.html
@@ -1,4 +1,5 @@
 {% set query = query %}
+{% set pageName = "search" %}
 
 {% extends "layouts/main.html" %}
 


### PR DESCRIPTION
Fixes #27

As per https://developer.matomo.org/guides/tracking-javascript-guide#internal-search-tracking

@edjw Please check that Site Search Analytics is turned on in the admin panel.