### PR TITLE
Update _search.html

### DIFF
--- a/views/partials/_search.html
+++ b/views/partials/_search.html
@@ -1,4 +1,4 @@
 <form action="/search" method="post" class="search{% if smallSearch %} small-search{% endif %}">
-  <input id="query=" name="query" type="text" placeholder="{% if smallSearch %}Search{% else %}Find an organisation by name{% endif %}" value="{% if not smallSearch %}{{ query }}{% endif %}" {% ifAsync pageName == "home" %}autofocus{% endif %} />
+<input id="query=" name="query" type="text" autocomplete="off" placeholder="{% if smallSearch %}Search{% else %}Find an organisation by name{% endif %}" value="{% if not smallSearch %}{{ query }}{% endif %}" {% ifAsync pageName == "home" %}autofocus{% endif %} />
   <button type="submit">Search</button>
 </form>


### PR DESCRIPTION
I saw an example of someone getting a previous Google search term autocompleting into the Data Rights Finder search box. This turns autocomplete to 'off' on the search box to ensure that doesn't happen.