### PR TITLE
Enable CORS on API endpoint routes

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const yaml = require('yamljs');
 const models = require('../models');
+const cors = require('cors');
 
 let settings = yaml.load('settings.yaml');
 
@@ -21,7 +22,7 @@ router.get('/', function(req, res, next) {
   });
 });
 
-router.get('/api/1/all', function(req, res, next) {
+router.get('/api/1/all', cors(), (req, res, next) => {
   models.Organisation.findAll({
     order: [
       ['name', 'ASC'],

--- a/controllers/organisation.js
+++ b/controllers/organisation.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 const tableify = require('tableify');
 const constants = require('../libs/constants');
 const models = require('../models');
+const cors = require('cors');
 
 const messageTemplates = require('../config/message_templates.js');
 const countries = require('../countries.json');
@@ -42,12 +43,12 @@ router.get('/organisation/:country/:number', function(req, res, next) {
   });
 });
 
-router.get('/organisation/:country/:number.json', function(req, res, next) {
+router.get('/organisation/:country/:number.json', cors(), (req, res, next) => {
   res.redirect(`/api/1/organisation/${req.params.country}/`
       + `${req.params.number}`);
 });
 
-router.get('/api/1/organisation/:country/:number', function(req, res, next) {
+router.get('/api/1/organisation/:country/:number', cors(), (req, res, next) => {
   models.Organisation.findOne({
     where: {
       registrationCountry: req.params.country,

--- a/controllers/search.js
+++ b/controllers/search.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const yaml = require('yamljs');
 const {check} = require('express-validator/check');
 const models = require('../models');
+const cors = require('cors');
 
 const settings = yaml.load('settings.yaml');
 
@@ -34,7 +35,7 @@ router.get('/search/:query', function(req, res, next) {
   });
 });
 
-router.get('/api/1/search/:query', function(req, res, next) {
+router.get('/api/1/search/:query', cors(), (req, res, next) => {
   let query = req.params.query;
 
   models.Organisation.findAll({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1138,6 +1138,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bower": "^1.8.4",
     "cheerio": "^1.0.0-rc.2",
     "clean-deep": "^3.0.2",
+    "cors": "^2.8.4",
     "dotenv": "^6.0.0",
     "express": "^4.15.2",
     "express-http-to-https": "^1.1.4",


### PR DESCRIPTION
CORS is a security feature that stops a website from making a request to get data from a URL, if that URL is not on the same domain as the requesting website. This is a good security feature, but stops third party websites from requesting data from DRF, particularly if the website uses React or jQuery.

To fix this, I've used the `cors` Node library to make an exception to the API endpoint addresses, so they can be requested by third party websites.