### PR TITLE
Require CHANGES_KEY to be set in env

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const Utils = require('./libs/utils.js');
 
 // STARTUP CHECKS
 if (Utils.checkForMissingEnvVars([
-  'DATABASE_URL', 'WEBHOOK_KEY', 'GITHUB_TOKEN',
+  'DATABASE_URL', 'WEBHOOK_KEY', 'GITHUB_TOKEN', 'CHANGES_KEY',
 ])) {
   process.exit();
 }


### PR DESCRIPTION
Make sure `CHANGES_KEY` is set in the environment variables before the app starts to prevent problems later on