### PR TITLE
Collapse changed companies on /changes and allow them to be expanded

### DIFF
--- a/assets/sass/_layout.scss
+++ b/assets/sass/_layout.scss
@@ -404,3 +404,10 @@ form.search {
     float: right;
   }
 }
+
+.changed-companies {
+  cursor: pointer;
+  background-color: #eeeeee;
+  padding: 1rem 0.5rem 1rem 1rem;
+  margin: 0.75rem 0;
+}

--- a/views/changes/index.html
+++ b/views/changes/index.html
@@ -34,12 +34,16 @@ $(function() {
     {% endif %}
 
     {% for organisation in changedOrganisations %}
-    <p>
-      <span class="org-name"><a href="/organisation/{{ organisation.registrationCountry }}/{{ organisation.registrationNumber }}" />{{ organisation.name }}</a></span>
-      <span class="ignore"><a href="/changes/ignore/{{ organisation.id }}?key={{ changesKey }}">Ignore</a></span>
-    </p>
+    <details class="changed-companies">
+      <p>
+        <summary>
+          <span class="org-name"><a href="/organisation/{{ organisation.registrationCountry }}/{{ organisation.registrationNumber }}" />{{ organisation.name }}</a></span>
+          <span class="ignore"><a href="/changes/ignore/{{ organisation.id }}?key={{ changesKey }}">Ignore</a></span>
+        </summary>
+      </p>
 
-    <pre class="diff_{{ organisation.registrationCountry }}{{ organisation.registrationNumber }}">{% if organisation.policyTextNew == null %}[PDF file]{% endif %}</pre>
+      <pre class="diff_{{ organisation.registrationCountry }}{{ organisation.registrationNumber }}">{% if organisation.policyTextNew == null %}[PDF file]{% endif %}</pre>
+    </details>
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
Using <details> and <summary> on the companies where privacy policies have been changed to create a collapsed accordion. Without this, all the text is revealed which is overwhelming and difficult to use.

<details> and <summary> are not supported by Edge or IE. Edge [intends to start development soon](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/detailssummary/).

I am not 100% sure what this would look like on IE or Edge at the moment. I hope it would just ignore these elements and therefore display the changes like they are in the current layout.